### PR TITLE
fixed issue 308 "Offload client's setting ignored"

### DIFF
--- a/server/generator.py
+++ b/server/generator.py
@@ -59,6 +59,10 @@
 #--
 #--  - 14/08/2024 Lyaaaaa
 #--    - Updated generate_text to work if assistant is null too.
+#--
+#--  - 25/06/2025 Lyaaaaa
+#--    - Updated _set_parameters to move to parent's method _set_parameters
+#--        the checks of _allow_offload and _offload_dict.
 #------------------------------------------------------------------------------
 
 from model        import Model
@@ -128,11 +132,6 @@ class Generator(Model):
       self._max_memory = {0     : p_parameters["max_memory"]["0"],
                           "cpu" : p_parameters["max_memory"]["cpu"]}
 
-    if self._allow_offload == True:
-      self._create_offload_folder()
-    elif self._allow_offload == None and p_parameters["allow_offload"] == True:
-      self._create_offload_folder()
-
 
     if self._allow_download == None:
       self._allow_download = p_parameters["allow_download"]
@@ -142,9 +141,6 @@ class Generator(Model):
 
     if self._torch_dtype == None:
       self._torch_dtype = Torch_Dtypes.dtypes.value[p_parameters["torch_dtype"]]
-
-    if self._offload_dict == None:
-      self._offload_dict = p_parameters["offload_dict"]
 
     if self._low_memory_mode == None:
       self._low_memory_mode  = p_parameters["low_memory_mode"]

--- a/server/model.py
+++ b/server/model.py
@@ -221,6 +221,14 @@
 #--  - 14/08/2024 Lyaaaaa
 #--    - Updated _get_gpu_info to make the prints more explicit.
 #--    - Added get_offload_folder
+#--
+#--  - 25/06/2025 Lyaaaaa
+#--    - Fix issue 308 "offloading always activated".
+#--      - Updated _set_parameters
+#--         - _allow_offload is now equal to client's setting if the config value is set to None
+#--         - _offload_dict has been moved up to model from generator.
+#--      - Updated _load_model the arguments offload_folder and offload_state_dict
+#--          are now set only if _allow_offload is True.
 #------------------------------------------------------------------------------
 
 from transformers import AutoModelForCausalLM, AutoModelForSeq2SeqLM, AutoTokenizer
@@ -314,7 +322,17 @@ class Model():
 #--
 #------------------------------------------------------------------------------
   def _set_parameters(self, p_parameters : dict):
-    # See children for implementation
+    # See children for complete implementation
+
+    if self._allow_offload == None:
+      self._allow_offload = p_parameters["allow_offload"]
+
+    if self._offload_dict == None:
+      self._offload_dict = p_parameters["offload_dict"]
+
+    if self._allow_offload == True:
+      self._create_offload_folder()
+
     logger.log.debug(p_parameters)
 
 
@@ -370,9 +388,11 @@ class Model():
       args = {"low_cpu_mem_usage"  : self._low_memory_mode,
               "device_map"         : self._device_map,
               "torch_dtype"        : self._torch_dtype,
-              "max_memory"         : self._max_memory,
-              "offload_folder"     : self._offload_folder,
-              "offload_state_dict" : self._offload_dict}
+              "max_memory"         : self._max_memory}
+
+      if self._allow_offload:
+        args["offload_folder" ] = self._offload_folder
+        args["offload_state_dict"] = self._offload_dict
 
       logger.log.debug("Model settings:")
       logger.log.debug(args)


### PR DESCRIPTION
generator.py:
- Updated _set_parameters to move to parent's method _set_parameters the checks of _allow_offload and _offload_dict.

model.py:
- Fix issue 308 "offloading always activated".
  - Updated _set_parameters
- _allow_offload is now equal to client's setting if the config value is set to None
    - _offload_dict has been moved up to model from generator.
- Updated _load_model the arguments offload_folder and offload_state_dict are now set only if _allow_offload is True.